### PR TITLE
CUDA9 deprecation warning fixed and GCC7 fixes

### DIFF
--- a/runtime/include/SharedMemory.h
+++ b/runtime/include/SharedMemory.h
@@ -153,7 +153,7 @@ class SharedMemoryClient: public SharedMemoryBase<T>
     using Header    = typename p::Header;
 
   public:
-    SharedMemoryClient(const std::string &descriptor, const double timeOut = HUGE) : p(descriptor) 
+    SharedMemoryClient(const std::string &descriptor, const double timeOut = HUGE_VAL) : p(descriptor) 
     {
       double dt = 0.0;
       while (p::shmfd < 0 && dt < timeOut)

--- a/runtime/src/parallel.cpp
+++ b/runtime/src/parallel.cpp
@@ -1142,7 +1142,7 @@ void octree::exchangeSamplesAndUpdateBoundarySFC(uint4 *sampleKeys2,    int  nSa
       MPI_Allreduce( &timeLocal, &timeSum, 1,MPI_DOUBLE, MPI_SUM, mpiCommWorld);
 
       double fmin = 0.0;
-      double fmax = HUGE;
+      double fmax = HUGE_VAL;
 
 /* evghenii: updated LB and MEMB part, works on the following synthetic test
       double lastExecTime = (double)nkeys_loc/nloc_mean;
@@ -1162,7 +1162,7 @@ void octree::exchangeSamplesAndUpdateBoundarySFC(uint4 *sampleKeys2,    int  nSa
         double fac = 1.0;
 
         fmin = fac/(1.0+mem_imballance);
-        fmax = HUGE;
+        fmax = HUGE_VAL;
 #if 0   /* use this to limit # of exported particles */
         fmax = fac*(1.0+mem_imballance);
 #endif


### PR DESCRIPTION
- Changed all `shfl` calls into `shfl.sync` operations
- Change defines that are no longer available in GCC7