### PR TITLE
Fix snapshot rate on restart

### DIFF
--- a/runtime/include/octree.h
+++ b/runtime/include/octree.h
@@ -699,6 +699,7 @@ public:
   //End library functions
 
   void set_t_current(const float t) { t_current = t_previous = t; }
+  void set_nextSnapTime(const float t) { nextSnapTime = t; }
   float get_t_current() const       { return t_current; }
   void setUseDirectGravity(bool s)  { useDirectGravity = s;    }
   bool getUseDirectGravity() const  { return useDirectGravity; }

--- a/runtime/src/main.cpp
+++ b/runtime/src/main.cpp
@@ -699,6 +699,7 @@ int main(int argc, char** argv, MPI_Comm comm, int shrMemPID)
         restartSim,
         reduce_bodies_factor);
     tree->set_t_current(tCurrent);
+    if (snapshotIter > 0) tree->set_nextSnapTime(tCurrent + snapshotIter);
 #else
     fprintf(stderr,"Usage of these options requires to code to be built with MPI support!\n"); exit(0);
 #endif      
@@ -714,6 +715,7 @@ int main(int argc, char** argv, MPI_Comm comm, int shrMemPID)
         MPI_Bcast(&tCurrent, 1, MPI_FLOAT, 0,mpiCommWorld);
         tree->set_t_current(tCurrent);
     #endif
+    if (snapshotIter > 0) tree->set_nextSnapTime(tree->get_t_current() + snapshotIter);
   }
   else if(nMilkyWay >= 0)
   {


### PR DESCRIPTION
The time for the next snapshot was not set. Causing it to take snapshots until the sum of `snapshotIter` equalled t_current. 